### PR TITLE
Include icons on distribution packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,8 @@ setup(name='%s_%s' % (PREFIX, MODULE),
         ],
     package_data={
         'trytond.modules.%s' % MODULE: (info.get('xml', [])
-            + ['tryton.cfg', 'locale/*.po', 'tests/*.rst', 'view/*.xml']),
+            + ['tryton.cfg', 'locale/*.po', 'tests/*.rst', 'view/*.xml',
+                'icons/*.svg']),
         },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Otherwise the module fails when innstalled.

P.S: It will be great to backport it to 5.6 and 5.4 series, since this was broken with https://github.com/trytonspain/trytond-activity/commit/b271b525fe2474e99da0ffda14887e60031d62ef